### PR TITLE
[FEATURE] TypeConverter to use Tokens as action argument

### DIFF
--- a/Classes/TypeConverter/TokenConverter.php
+++ b/Classes/TypeConverter/TokenConverter.php
@@ -1,0 +1,43 @@
+<?php
+namespace Flownative\DoubleOptIn\TypeConverter;
+
+/*                                                                        *
+ * This is free software; you can redistribute it and/or modify it under  *
+ * the terms of the MIT license                                           *
+ *                                                                        */
+
+use Flownative\DoubleOptIn\Helper;
+use Flownative\DoubleOptIn\Token;
+use TYPO3\Flow\Property\TypeConverter\AbstractTypeConverter;
+
+/**
+ * Convert a string (tokenHash) into a Token object.
+ */
+class TokenConverter extends AbstractTypeConverter {
+
+	/**
+	 * @var array
+	 */
+	protected $sourceTypes = ['string'];
+
+	/**
+	 * @var string
+	 */
+	protected $targetType = 'Flownative\DoubleOptIn\Token';
+
+	/**
+	 * Actually convert from $source to $targetType, taking into account the fully
+	 * built $convertedChildProperties and $configuration.
+	 *
+	 * @param mixed $source
+	 * @param string $targetType
+	 * @param array $convertedChildProperties
+	 * @param \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration
+	 *
+	 * @return Token|NULL the target type, or NULL if it was not a valid token
+	 */
+	public function convertFrom($source, $targetType, array $convertedChildProperties = [], \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = NULL) {
+		$doubleOptinHelper = new Helper();
+		return $doubleOptinHelper->validateTokenHash($source);
+	}
+}


### PR DESCRIPTION
Allows to annotate a token as an action argument. Transmitting the
`tokenHash` will try to fetch the token from cache if the hash did
not validate NULL is returned so the action should cope with that.
