### PR TITLE
[BUGFIX] Assign fully resolved preset to Token

### DIFF
--- a/Classes/Helper.php
+++ b/Classes/Helper.php
@@ -69,7 +69,7 @@ class Helper {
 			$preset['lifetime']
 		);
 
-		return new Token($tokenHash, $identifier, $presetName, $meta);
+		return new Token($tokenHash, $identifier, $preset, $meta);
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Helper {
 		$tokenData = $this->tokenCache->get($tokenHash);
 		$this->tokenCache->remove($tokenHash);
 
-		return new Token($tokenHash, $tokenData['identifier'], $tokenData['presetName'], $tokenData['meta']);
+		return new Token($tokenHash, $tokenData['identifier'], $this->getPreset($tokenData['presetName']), $tokenData['meta']);
 	}
 
 	/**

--- a/Classes/Token.php
+++ b/Classes/Token.php
@@ -16,12 +16,6 @@ use TYPO3\Flow\Annotations as Flow;
 class Token {
 
 	/**
-	 * @Flow\InjectConfiguration(path="presets")
-	 * @var array
-	 */
-	protected $presets;
-
-	/**
 	 * @var string
 	 */
 	protected $hash;
@@ -32,9 +26,9 @@ class Token {
 	protected $identifier;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $presetName;
+	protected $preset;
 
 	/**
 	 * @var array
@@ -46,13 +40,13 @@ class Token {
 	 *
 	 * @param string $hash
 	 * @param string $identifier
-	 * @param string $presetName
+	 * @param string $preset
 	 * @param array $meta
 	 */
-	public function __construct($hash, $identifier, $presetName, array $meta = []) {
+	public function __construct($hash, $identifier, array $preset, array $meta = []) {
 		$this->hash = $hash;
 		$this->identifier = $identifier;
-		$this->presetName = $presetName;
+		$this->preset = $preset;
 		$this->meta = $meta;
 	}
 
@@ -82,7 +76,7 @@ class Token {
 	 * @return array
 	 */
 	public function getPreset() {
-		return isset($this->presets[$this->presetName]) ? $this->presets[$this->presetName] : [];
+		return $this->preset;
 	}
 
 	/**


### PR DESCRIPTION
The preset fetched from a Token would not be fully resolved (merged
with the 'default' preset values). Now the preset is resolved and
assigned instead of just passing the preset name and fetching it
straight from settings in the Token.
