### PR TITLE
[BUGFIX] TokenConverter returns FALSE on error

### DIFF
--- a/Classes/Helper.php
+++ b/Classes/Helper.php
@@ -75,12 +75,14 @@ class Helper {
 	/**
 	 * This checks if a given hash is known and still valid before returning the associated Token.
 	 *
+	 * If no valid Token is found for the hash, NULL is returned.
+	 *
 	 * @param $tokenHash
-	 * @return boolean|Token
+	 * @return Token
 	 */
 	public function validateTokenHash($tokenHash) {
 		if (!$this->tokenCache->has($tokenHash)) {
-			return FALSE;
+			return NULL;
 		}
 
 		$tokenData = $this->tokenCache->get($tokenHash);

--- a/Classes/TypeConverter/TokenConverter.php
+++ b/Classes/TypeConverter/TokenConverter.php
@@ -38,7 +38,6 @@ class TokenConverter extends AbstractTypeConverter {
 	 */
 	public function convertFrom($source, $targetType, array $convertedChildProperties = [], \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = NULL) {
 		$doubleOptinHelper = new Helper();
-		$token =  $doubleOptinHelper->validateTokenHash($source);
-		return $token instanceof Token ? $token : NULL;
+		return $doubleOptinHelper->validateTokenHash($source);
 	}
 }

--- a/Classes/TypeConverter/TokenConverter.php
+++ b/Classes/TypeConverter/TokenConverter.php
@@ -38,6 +38,7 @@ class TokenConverter extends AbstractTypeConverter {
 	 */
 	public function convertFrom($source, $targetType, array $convertedChildProperties = [], \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = NULL) {
 		$doubleOptinHelper = new Helper();
-		return $doubleOptinHelper->validateTokenHash($source);
+		$token =  $doubleOptinHelper->validateTokenHash($source);
+		return $token instanceof Token ? $token : NULL;
 	}
 }


### PR DESCRIPTION
The converter advertised it returned a Token instance or NULL, but in
fact when hash validation failed it returned FALSE. That has been
changed, so the converter actually does return NULL if an invalid
token hash is given.
