### PR TITLE
[FEATURE] Allow use of UriBuilder for activation link generation

### DIFF
--- a/Classes/Helper.php
+++ b/Classes/Helper.php
@@ -122,6 +122,7 @@ class Helper {
 			$this->uriBuilder->setRequest($this->request);
 			$uri = $this->uriBuilder
 				->setCreateAbsoluteUri(TRUE)
+				->setFormat($routerConfiguration['@format'])
 				->uriFor(
 					$routerConfiguration['@action'],
 					$routerConfiguration['arguments'],

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,9 +9,19 @@ Flownative:
         lifetime: 86400
         # configuration for building an activation link for a token
         activation:
-          # if uri is given as a string, the placeholder %s will be replaced with the token
-          # not yet implemented: if uri is a hash, it is assumed to be UriBuilder input as used in Routes.yaml
-          uri: ~
+          # if uri is given as a string, it is used as given.
+          # the placeholder -tokenhash- will be replaced with the token hash
+          # uri: 'http://acme.com/activate/-tokenhash-'
+
+          # if uri is a hash it is used as UriBuilder input (like in Routes.yaml)
+          # the placeholder -tokenhash- will be replaced with the token hash in the built uri
+          uri:
+            '@package': ~
+            '@subpackage': ~
+            '@controller': ~
+            '@format': ~
+            '@action': ~
+            arguments: ~
         mail:
           # name and email address to use for activation mails
           from:

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -53,7 +53,7 @@ To adjust this default preset, override as usual:
          'default':
            tokenLength: 8
            activation:
-             uri: 'http://acme.com/?validate=%s'
+             uri: 'http://acme.com/?validate=-tokenhash-'
 
 To create a custom preset, simply specify the needed differences to the `default` preset, the
 settings are merged with the defaults before use.


### PR DESCRIPTION
When the activation.uri setting is a hash, it is assumed to be router
input and will be used to build the activation URI in the Helper.
