### PR TITLE
FEATURE: Make consumption of tokens configurable in preset

### DIFF
--- a/Classes/Helper.php
+++ b/Classes/Helper.php
@@ -110,12 +110,29 @@ class Helper {
 			return NULL;
 		}
 
-		$this->tokenCache->remove($tokenHash);
+		$preset = $this->getPreset($tokenData['presetName']);
+		if (! (isset($preset['preserveToken']) && $preset['preserveToken'])) {
+			$this->tokenCache->remove($tokenHash);
+		}
 
 		$this->logger->log(sprintf('Validated token hash %s for identifier %s', $tokenHash, $tokenData['identifier']), LOG_INFO);
 
 		return new Token($tokenHash, $tokenData['identifier'], $this->getPreset($tokenData['presetName']), $tokenData['meta']);
 	}
+
+    /**
+     * Removes the given token from the token cache.
+     *
+     * This is only necessary if the 'preserveToken' parameter of the token's preset is true. Otherwise tokens are deleted automatically.
+     *
+     * @param Token $token
+     */
+	public function invalidateToken(Token $token)
+    {
+        $this->tokenCache->remove($token->getHash());
+
+        $this->logger->log(sprintf('Deleted token %s.', $token->getIdentifier()), LOG_INFO);
+    }
 
 	/**
 	 * For the given $token an activation link is returned.

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,6 +7,8 @@ Flownative:
         tokenLength: 32
         # how long a token should be valid after generation, in seconds
         lifetime: 86400
+        # if set to true, tokens are not removed from cache automatically when the activation link is called
+        preserveToken: true
         # configuration for building an activation link for a token
         activation:
           # if uri is given as a string, it is used as given.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -40,7 +40,7 @@ following `default` preset is used:
 
 .. literalinclude:: ../Configuration/Settings.yaml
    :language: yaml
-   :lines: 1-27
+   :lines: 1-39
    :emphasize-lines: 5-
 
 To adjust this default preset, override as usual:


### PR DESCRIPTION
Allows the user to define in the respective preset whether the cache entry of the token should be deleted automatically or not.